### PR TITLE
fix toc's malpostion during resizing

### DIFF
--- a/source/js/post.js
+++ b/source/js/post.js
@@ -2,7 +2,6 @@ $(document).ready(function(){
     var navHeight = $("#navbar").height();
     var toc = $("#toc");
     var main = $("main");
-    var tocL = toc.offset().left;
     var tocT = navHeight + (toc.offset().top - main.offset().top);
     var tocLimMin = main.offset().top - navHeight;
     var tocLimMax = $("#comments").offset().top - navHeight;
@@ -12,13 +11,11 @@ $(document).ready(function(){
             toc.css({
                 "display": "block",
                 "position": "fixed",
-                "left": tocL,
                 "top": tocT
             })
         }else if(scroH <= tocLimMin){  
             toc.css({
                 "position": "",
-                "left": '',
                 "top": ''
             })
         } else if(scroH > tocLimMax){


### PR DESCRIPTION
Hi，很好看的主题。背景图真滴好看✔

我用的时候发现toc的位置不能随浏览器的缩放一起运动，从下面两个截图能看到这个bug。当浏览器从全屏变为窗口模式时，甚至不能看到toc。

所以我解除了toc的左侧坐标限制，让它跟随自己的容器运动就好

![toc1](https://user-images.githubusercontent.com/49832303/57295695-a479e700-70fd-11e9-9214-f76f9a61980d.png)


![toc2](https://user-images.githubusercontent.com/49832303/57295685-9c21ac00-70fd-11e9-948a-194f118fb753.png)
